### PR TITLE
feat(web): add configurable devices to local preview

### DIFF
--- a/apps/web/src/i18n/messages/en-US.json
+++ b/apps/web/src/i18n/messages/en-US.json
@@ -467,6 +467,21 @@
       "desktop": "Desktop",
       "tablet": "Tablet",
       "mobile": "Mobile"
+    },
+    "add": {
+      "button": "Add device",
+      "capacity": "{current} / {max} devices",
+      "title": "Add debug device",
+      "description": "The new device joins this local room as an independent player.",
+      "nameLabel": "Player name",
+      "deviceLabel": "Device model",
+      "defaultName": "Player {number}",
+      "nameRequired": "Enter a player name.",
+      "nameTaken": "That player name is already in use.",
+      "capacityReached": "The room has reached its player limit.",
+      "failed": "Could not add device: {error}",
+      "cancel": "Cancel",
+      "confirm": "Add device"
     }
   },
   "devTools": {

--- a/apps/web/src/i18n/messages/zh-CN.json
+++ b/apps/web/src/i18n/messages/zh-CN.json
@@ -467,6 +467,21 @@
       "desktop": "桌面",
       "tablet": "平板",
       "mobile": "手机"
+    },
+    "add": {
+      "button": "添加设备",
+      "capacity": "{current} / {max} 个设备",
+      "title": "添加调试设备",
+      "description": "新设备会以独立玩家身份加入同一个本地房间。",
+      "nameLabel": "玩家名称",
+      "deviceLabel": "设备型号",
+      "defaultName": "玩家 {number}",
+      "nameRequired": "请输入玩家名称。",
+      "nameTaken": "该玩家名称已在使用。",
+      "capacityReached": "房间已达到玩家人数上限。",
+      "failed": "添加设备失败：{error}",
+      "cancel": "取消",
+      "confirm": "添加设备"
     }
   },
   "devTools": {

--- a/apps/web/src/pages/LocalRoomView.tsx
+++ b/apps/web/src/pages/LocalRoomView.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { PlusIcon } from 'lucide-react';
 import type { RoomClientPort } from '@parti/client-sdk';
 import { type RoomPackage } from '@parti/room-packager';
 import { ROOM_FRAME_GRID_AREAS, RoomFrame, type RoomFrameGridKey } from '../components/RoomFrame';
@@ -7,12 +8,38 @@ import { DevTools } from '../components/DevTools';
 import { LocalRoomSession } from '../lib/LocalRoomSession';
 import { loadRoomSnapshot } from '../lib/customRooms';
 import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+type DeviceKind = 'desktop' | 'tablet' | 'mobile';
+
+/**
+ * 与首屏的 Host / Alice / Bob 完全相同的画布占用尺寸。
+ * 追加设备从第 13 行起自动密集排布，因而不会压缩或改变任何设备型号的测试尺寸。
+ */
+const DEVICE_GRID_SPANS: Record<DeviceKind, CSSProperties> = {
+  desktop: { gridColumn: 'span 7 / span 7', gridRow: 'span 7 / span 7' },
+  tablet: { gridColumn: 'span 10 / span 10', gridRow: 'span 5 / span 5' },
+  mobile: { gridColumn: 'span 3 / span 3', gridRow: 'span 7 / span 7' },
+};
 
 interface Seat {
+  id: string;
+  name: string;
   label: string;
   role: string;
   port: RoomClientPort;
-  gridKey: RoomFrameGridKey;
+  device: DeviceKind;
+  gridKey?: RoomFrameGridKey;
 }
 
 interface Loaded {
@@ -21,11 +48,16 @@ interface Loaded {
   seats: Seat[];
 }
 
-/** 本地多人预览：一个 Host + 2 个虚拟玩家，全部经真实 worker / iframe 沙箱跑通。 */
+/** 本地多人预览：一个 Host 和可按需增加的虚拟玩家，全部经真实 worker / iframe 沙箱跑通。 */
 export function LocalRoomView({ roomId }: { roomId: string }) {
   const intl = useIntl();
   const [loaded, setLoaded] = useState<Loaded | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [deviceName, setDeviceName] = useState('');
+  const [deviceKind, setDeviceKind] = useState<DeviceKind>('mobile');
+  const [addError, setAddError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -46,18 +78,27 @@ export function LocalRoomView({ roomId }: { roomId: string }) {
         pkg,
         seats: [
           {
+            id: 'host',
+            name: intl.formatMessage({ id: 'local.seat.host' }),
             label: `${intl.formatMessage({ id: 'local.seat.host' })} · ${intl.formatMessage({ id: 'local.device.desktop' })}`,
             role: 'host', port: hostPort,
+            device: 'desktop',
             gridKey: 'desktop',
           },
           {
+            id: 'alice',
+            name: 'Alice',
             label: `${intl.formatMessage({ id: 'local.seat.alice' })} · ${intl.formatMessage({ id: 'local.device.tablet' })}`,
             role: 'player', port: p1,
+            device: 'tablet',
             gridKey: 'tablet',
           },
           {
+            id: 'bob',
+            name: 'Bob',
             label: `${intl.formatMessage({ id: 'local.seat.bob' })} · ${intl.formatMessage({ id: 'local.device.mobile' })}`,
             role: 'player', port: p2,
+            device: 'mobile',
             gridKey: 'phone',
           },
         ],
@@ -83,34 +124,149 @@ export function LocalRoomView({ roomId }: { roomId: string }) {
     return <div className="p-[22px] text-center text-[13px] text-muted-foreground"><FormattedMessage id="local.loading" /></div>;
   }
 
+  const active = loaded;
+  const maxPlayers = active.pkg.manifest.room?.maxPlayers;
+  const atCapacity = maxPlayers !== undefined && active.seats.length >= maxPlayers;
+
+  function deviceLabel(kind: DeviceKind): string {
+    return intl.formatMessage({ id: `local.device.${kind}` });
+  }
+
+  function openAddDialog(): void {
+    if (atCapacity) return;
+    setDeviceName(intl.formatMessage({ id: 'local.add.defaultName' }, { number: active.seats.length + 1 }));
+    setDeviceKind('mobile');
+    setAddError(null);
+    setAddDialogOpen(true);
+  }
+
+  async function addDevice(): Promise<void> {
+    const name = deviceName.trim().replace(/\s+/g, ' ');
+    if (!name) {
+      setAddError(intl.formatMessage({ id: 'local.add.nameRequired' }));
+      return;
+    }
+    if (active.seats.some((seat) => seat.name.localeCompare(name, undefined, { sensitivity: 'accent' }) === 0)) {
+      setAddError(intl.formatMessage({ id: 'local.add.nameTaken' }));
+      return;
+    }
+    if (atCapacity) {
+      setAddError(intl.formatMessage({ id: 'local.add.capacityReached' }));
+      return;
+    }
+
+    setAdding(true);
+    setAddError(null);
+    try {
+      const port = await active.session.addPlayer(name);
+      setLoaded((current) => {
+        if (!current || current.session !== active.session) return current;
+        const id = `virtual-${current.seats.length}`;
+        return {
+          ...current,
+          seats: [...current.seats, {
+            id,
+            name,
+            label: `${name} · ${deviceLabel(deviceKind)}`,
+            role: 'player',
+            port,
+            device: deviceKind,
+          }],
+        };
+      });
+      setAddDialogOpen(false);
+    } catch (reason) {
+      setAddError(intl.formatMessage(
+        { id: 'local.add.failed' },
+        { error: reason instanceof Error ? reason.message : String(reason) },
+      ));
+    } finally {
+      setAdding(false);
+    }
+  }
+
   return (
     <div className="mx-auto w-[min(1240px,100%)]">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
         <h2 className="text-2xl font-semibold">
           {intl.formatMessage({ id: 'local.title' }, { name: loaded.pkg.manifest.name })}
         </h2>
+        <div className="flex items-center gap-3">
+          {maxPlayers !== undefined && (
+            <span className="text-xs text-muted-foreground">
+              {intl.formatMessage({ id: 'local.add.capacity' }, { current: loaded.seats.length, max: maxPlayers })}
+            </span>
+          )}
+          <Button type="button" className="gap-2" onClick={openAddDialog} disabled={atCapacity}>
+            <PlusIcon />
+            <FormattedMessage id="local.add.button" />
+          </Button>
+        </div>
       </div>
       <div
-        className="mb-4 grid w-full grid-cols-10 grid-rows-12 gap-2"
-        style={{ height: 'min(calc(160dvh - 200px), 1600px)' }}
+        className="mb-4 grid w-full grid-flow-row-dense grid-cols-10 gap-2"
+        style={{
+          gridAutoRows: 'calc((min(calc(160dvh - 200px), 1600px) - 88px) / 12)',
+        }}
       >
-        {loaded.seats.map((seat) => (
+        {active.seats.map((seat) => (
           <RoomFrame
-            key={seat.label}
-            pkg={loaded.pkg}
+            key={seat.id}
+            pkg={active.pkg}
             port={seat.port}
             label={seat.label}
             role={seat.role}
-            style={ROOM_FRAME_GRID_AREAS[seat.gridKey]}
+            style={seat.gridKey ? ROOM_FRAME_GRID_AREAS[seat.gridKey] : DEVICE_GRID_SPANS[seat.device]}
             viewport={{ fill: true }}
           />
         ))}
       </div>
       <DevTools
         host={loaded.session.host}
-        packageHash={loaded.pkg.packageHash}
+        packageHash={active.pkg.packageHash}
         transportName="local"
       />
+      <Dialog open={addDialogOpen} onOpenChange={(open) => { if (!adding) setAddDialogOpen(open); }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle><FormattedMessage id="local.add.title" /></DialogTitle>
+            <DialogDescription><FormattedMessage id="local.add.description" /></DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-2">
+            <label className="grid gap-2 text-sm font-medium" htmlFor="local-device-name">
+              <FormattedMessage id="local.add.nameLabel" />
+              <Input
+                id="local-device-name"
+                maxLength={24}
+                value={deviceName}
+                onChange={(event) => setDeviceName(event.target.value)}
+                onKeyDown={(event) => { if (event.key === 'Enter') void addDevice(); }}
+                disabled={adding}
+              />
+            </label>
+            <label className="grid gap-2 text-sm font-medium" htmlFor="local-device-kind">
+              <FormattedMessage id="local.add.deviceLabel" />
+              <Select value={deviceKind} onValueChange={(value) => setDeviceKind(value as DeviceKind)} disabled={adding}>
+                <SelectTrigger id="local-device-kind"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(DEVICE_GRID_SPANS) as DeviceKind[]).map((kind) => (
+                    <SelectItem key={kind} value={kind}>{deviceLabel(kind)}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+            {addError && <p className="text-sm text-destructive" role="alert">{addError}</p>}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" disabled={adding} onClick={() => setAddDialogOpen(false)}>
+              <FormattedMessage id="local.add.cancel" />
+            </Button>
+            <Button type="button" disabled={adding} onClick={() => void addDevice()}>
+              <FormattedMessage id="local.add.confirm" />
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/docs/example-tic-tac-toe.md
+++ b/docs/example-tic-tac-toe.md
@@ -292,8 +292,8 @@ export default defineRoom({
 pnpm dev   # http://localhost:5173
 ```
 
-把上面三个文件放进 `apps/web/public/rooms/tic-tac-toe/`，用「本地预览（Host+2 玩家）」
-即可两个虚拟玩家对弈；或用 PeerJS 模式生成邀请链接真人联机。
+把上面三个文件放进 `apps/web/public/rooms/tic-tac-toe/`，用「本地预览（Host+2 位初始玩家）」
+即可两个虚拟玩家对弈；右上角还可按需添加命名的虚拟设备。或用 PeerJS 模式生成邀请链接真人联机。
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,9 +155,10 @@ pnpm dev        # 启动 Web 应用 http://localhost:5157
 
 打开应用后有两种运行方式：
 
-- **本地预览（Host + 2 玩家）**：单页内用内存 transport 起 1 个房主 + 2 个虚拟玩家，
-  每人一个沙箱 iframe，房间逻辑跑在真实 Web Worker。适合开发调试，DevTools 会显示
-  state / version / 消息日志。
+- **本地预览（Host + 2 位初始玩家）**：单页内用内存 transport 起 1 个房主 + 2 个虚拟玩家，
+  每人一个沙箱 iframe，房间逻辑跑在真实 Web Worker。右上角的「添加设备」可继续加入虚拟
+  玩家（不超过 manifest 的 `maxPlayers`），并选择桌面、平板或手机外框及玩家名称。适合开发
+  调试，DevTools 会显示 state / version / 消息日志。
 - **PeerJS 联机**：先设置运行实例标题和可选 4 位密码，再由房主生成邀请链接。
   房间默认私密；配置大厅服务后可在房主面板公开。**同一份房间代码在两种模式下
   零改动**。
@@ -198,7 +199,9 @@ Room 应用不应硬编码到 Web 的相对路径。`room-*` 的生成目录已�
 完整打包规范（Vite 配置、Worker esbuild 插件、产物契约）见
 [room-dev-harness.md](./room-dev-harness.md)。
 
-本地多人预览中的 Host、Alice、Bob 分别使用桌面、平板和手机比例。三个 iframe 都会
+本地多人预览初始的 Host、Alice、Bob 分别使用桌面、平板和手机比例。调试者可在右上角
+继续添加命名的虚拟设备，并选择其外框比例；新增设备会复用对应初始设备的同一画布尺寸
+（桌面与 Host、平板与 Alice、手机与 Bob 一致），再按密集网格自动排布。所有 iframe 都会
 随页面宽度响应式缩放，用于观察不同布局比例，而不是模拟固定型号或固定像素分辨率。
 
 ### 让自己的房间被官方列表加载


### PR DESCRIPTION
## Summary

- add an **Add device** dialog to local multiplayer preview, with a player name and desktop/tablet/mobile frame choice
- enforce each room manifest's `maxPlayers` limit and guard against empty or duplicate device names
- retain the original Host/Alice/Bob viewport sizes; extra frames use the same spans and flow into a dense grid without shrinking the initial devices
- add English/Chinese UI strings and document the local-preview workflow

## Validation

- `tsc -b`
- `vite build` in `apps/web`
- `vitest run` (659/660 tests pass; the existing `packages/core/test/reconnect.test.ts` grace-period assertion fails, outside this change)

Browser gameplay verification was intentionally left to human testing.